### PR TITLE
Fix coalition setup bug in NEE effect

### DIFF
--- a/common/scripted_effects/NEE effects (New England).txt
+++ b/common/scripted_effects/NEE effects (New England).txt
@@ -581,12 +581,13 @@ NEE_Congress_Coalition = {
 		# Add the Democrat Party as a 20% coalition member
 		custom_effect_tooltip = NEE_Democrat_cabinet_tooltip
 		hidden_effect = {
-			set_variable = { NEE.coalition_stability = 0.2 }
-			set_temp_variable = { coalition_partner_var = token:social_liberal }
-			set_temp_variable = { coalition_partner_var = token:social_conservative }
-			add_to_coalition = yes
-		}
-	}
+                        set_variable = { NEE.coalition_stability = 0.2 }
+                        set_temp_variable = { coalition_partner_var = token:social_liberal }
+                        add_to_coalition = yes
+                        set_temp_variable = { coalition_partner_var = token:social_conservative }
+                        add_to_coalition = yes
+                }
+        }
 	# Democrat #
 	else_if = {
 		limit = {


### PR DESCRIPTION
## Summary
- fix coalition setup for New England congress effect so both liberal and conservative partners are added correctly

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6840c554ddf08324bd1efd256598d482