### PR TITLE
Fix duplicate character in Russia history

### DIFF
--- a/history/countries/RUS - Russia.txt
+++ b/history/countries/RUS - Russia.txt
@@ -674,10 +674,6 @@ RUS_gordey_levchenko = {
 	set_character_flag = RUS_socialist
 	set_nationality = XXA
 }
-RUS_georgy_zhukov = {
-	set_character_flag = RUS_socialist
-	set_nationality = XXA
-}
 
 # RUS_neutral for neutral Latvian USSR generals
 RUS_aleksandr_vasilevsky = { set_character_flag = RUS_neutral }

--- a/history/countries/RUS - Russia.txt
+++ b/history/countries/RUS - Russia.txt
@@ -125,7 +125,6 @@ if = {
 		basic_depth_charges = 1
 		basic_naval_mines = 1
 		submarine_mine_laying = 1
-		basic_depth_charges = 1
 		basic_cruiser_armor_scheme = 1
 
 		### Transport ###


### PR DESCRIPTION
## Summary
- remove duplicate `RUS_georgy_zhukov` setup block in Russia history file
- Deleted the second basic_depth_charges line in the Russian history file to avoid assigning the tech twice

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841c6634e9c8324878107cd5cd7821d