### PR TITLE
Fix Germany state victory point mismatch

### DIFF
--- a/history/states/64 - Brandenburg.txt
+++ b/history/states/64 - Brandenburg.txt
@@ -9,7 +9,7 @@ state = {
 		add_core_of = GER
 		add_to_array = { state_victory_points = 6521 }
 		add_to_array = { state_victory_points = 9496 }
-		add_to_array = { state_victory_points = 11414 }
+               add_to_array = { state_victory_points = 11415 }
 		victory_points = { 6521 50 }
 		victory_points = { 9496 1 }
 		victory_points = { 11415 3 }


### PR DESCRIPTION
## Summary
- fix mismatched victory point id for Brandenburg state history file

## Testing
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_6841cb434bc48324856ac48589b01d1b